### PR TITLE
Format YAML files and unify the dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,15 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic
   - package-ecosystem: npm
     directory: "/"
+    open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
+---
 name: "CI"
-on:
+"on":
   push:
     branches: "*"
   pull_request:
@@ -22,7 +23,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -51,7 +54,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
+---
 name: "Deploy"
-on:
+"on":
   release:
     types: [published]
   workflow_dispatch:
@@ -17,7 +18,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-


### PR DESCRIPTION
Two independent commits; they can be reviewed separately.

## 1. `Format and lint YAML files`

Conform every YAML file in the repository to yamllint's default rules,
which previously reported a large number of issues:

- Add the `---` document start marker.
- Quote the `on:` workflow key so it is not parsed as the boolean true.
- Indent block sequences under their parent key, which was previously
  inconsistent even within a single file.
- Fold over-long values into `>-` block scalars. Every folded value is
  preserved byte for byte.

Verified by comparing every file before and after as parsed YAML: apart
from the changes listed above, no key or value differs. The remaining
long lines are `restore-keys` entries and shell lines inside `run: |`
blocks, which cannot be wrapped without changing their meaning.

## 2. `Unify the dependabot schedule across repositories`

Set every dependabot ecosystem to a weekly schedule with an effectively
unlimited number of open pull requests:

- `interval: weekly`
- `open-pull-requests-limit: 9999` (GitHub's default is 5)

Until now these settings tracked whether the repository had dependabot
auto-merge: the repositories with it used weekly/9999, while those without
used daily and the default limit, so that dependency PRs arrived in small
batches for manual review. Auto-merge is now enabled everywhere, so that
distinction no longer applies.

Ecosystems, directories and assignees are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)